### PR TITLE
Patch for restforce https://nvd.nist.gov/vuln/detail/CVE-2018-3777

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ test/version_tmp
 tmp
 .ruby-version
 .ruby-gemset
+
+# Rubymine specific
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Not released
 
+## 0.7.2
+
+* Updated restforce to v3.0.0 to patch https://nvd.nist.gov/vuln/detail/CVE-2018-3777
+
 ## 0.7.1
 
 * Allow sfdc_client to be set. ([#92][])

--- a/active_force.gemspec
+++ b/active_force.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9.3'
 
   spec.add_dependency 'active_attr', '~> 0.10.2'
-  spec.add_dependency 'restforce',   '~> 2.5.3'
+  spec.add_dependency 'restforce',   '>= 3.0.0'
   spec.add_development_dependency 'bundler', '~> 1.15.4'
   spec.add_development_dependency 'rake', '>= 0'
   spec.add_development_dependency 'rspec', '>= 0'

--- a/lib/active_force/version.rb
+++ b/lib/active_force/version.rb
@@ -1,3 +1,3 @@
 module ActiveForce
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end


### PR DESCRIPTION
Update restforce to v3.0.0